### PR TITLE
ensure certificate revocation list database exists (#45)

### DIFF
--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -41,8 +41,11 @@
     masquerade: true
     zone: "{{firewalld_default_interface_zone}}"
     permanent: true
-    immediate: true
     state: enabled
+    #Workarround ansible issue: https://github.com/ansible/ansible/pull/21693
+    #immediate: true
+  notify:
+    - restart firewalld
 
 # workaround for --permanent not working on non-NetworkManager managed ifaces
 # https://bugzilla.redhat.com/show_bug.cgi?id=1112742

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -127,9 +127,13 @@
     group: root
     mode: 744
 
+- name: ensure certificate revocation list database exists
+  file:
+    path: "{{openvpn_key_dir}}/index.txt"
+    state: touch
+
 - name: set up certificate revocation list
   command: sh revoke.sh
   args:
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ openvpn_key_dir }}/ca-crl.pem"
-


### PR DESCRIPTION
* workaround ansible issue "set_masquerade_enabled"

ERROR: Exception caught: set_masquerade_enabled() takes exactly 1 argument (6 given)"
https://github.com/ansible/ansible/pull/21693

* my fork not in ansible galaxy

* make sure crl database file exists

* Revert "my fork not in ansible galaxy"

This reverts commit af1d9c3a464934d8597ab6e4468c20a15161ee7c.